### PR TITLE
buffer usb > 0

### DIFF
--- a/src/picostdlib/pico/stdio.nim
+++ b/src/picostdlib/pico/stdio.nim
@@ -175,7 +175,7 @@ proc print*(s: string) =
 proc stdinReadLine*(echoInput: bool = true): string =
   while true:
     let res = getcharTimeoutUs(100_000)
-    if res != PicoErrorTimeout.int:
+    if res >= 0 and res != PicoErrorTimeout.int:
       let character = res.char
       if character == '\r':
         echo ""


### PR DESCRIPTION
I noticed that if the USB buffer is "empty" a negative number returns (example -2) and this gives problems on conversion into character by sending the program to Chrah, this correction should solve the problem.
